### PR TITLE
fix Windows pdf delete problem

### DIFF
--- a/org.eclipse.ui.views.pdf/META-INF/MANIFEST.MF
+++ b/org.eclipse.ui.views.pdf/META-INF/MANIFEST.MF
@@ -11,7 +11,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.swt.util;bundle-version="0.0.0",
  org.eclipse.util;bundle-version="0.0.0";visibility:=reexport,
  org.eclipse.ui.views.file;bundle-version="0.1.0";visibility:=reexport,
- org.eclipse.ui.ide;bundle-version="3.6.0"
+ org.eclipse.ui.ide;bundle-version="3.6.0",
+ org.eclipse.ltk.core.refactoring
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.eclipse.ui.views.pdf
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.ui.views.pdf/build.properties
+++ b/org.eclipse.ui.views.pdf/build.properties
@@ -2,4 +2,5 @@ source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\
-               icons/
+               icons/,\
+               plugin.xml

--- a/org.eclipse.ui.views.pdf/plugin.xml
+++ b/org.eclipse.ui.views.pdf/plugin.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.0"?>
+<plugin>
+  <extension point="org.eclipse.ltk.core.refactoring.deleteParticipants">
+    <deleteParticipant class="org.eclipse.ui.views.pdf.DeletePdfParticipant" id="org.eclipse.ui.views.pdf.deleteParticipants.File" name="Close Score View">
+      <enablement>
+        <with variable="element">
+          <instanceof value="org.eclipse.core.resources.IFile"/>
+        </with>
+      </enablement>
+    </deleteParticipant>
+    <deleteParticipant class="org.eclipse.ui.views.pdf.DeletePdfParticipant" id="org.eclipse.ui.views.pdf.deleteParticipants.Folder" name="Close Score View">
+      <enablement>
+        <with variable="element">
+          <instanceof value="org.eclipse.core.resources.IFolder"/>
+        </with>
+      </enablement>
+    </deleteParticipant>
+  </extension>
+</plugin>

--- a/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/DeletePdfParticipant.java
+++ b/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/DeletePdfParticipant.java
@@ -1,0 +1,93 @@
+package org.eclipse.ui.views.pdf;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceVisitor;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.ltk.core.refactoring.Change;
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+import org.eclipse.ltk.core.refactoring.participants.CheckConditionsContext;
+import org.eclipse.ltk.core.refactoring.participants.DeleteParticipant;
+import org.eclipse.ui.IViewPart;
+import org.eclipse.ui.IViewReference;
+import org.eclipse.ui.views.file.FileView;
+import org.eclipse.ui.views.file.IFileViewType;
+import org.eclipse.util.UiUtils;
+
+public class DeletePdfParticipant extends DeleteParticipant {
+
+	@Override
+	protected boolean initialize(Object element) {
+		List<IFile> filesToDelete = getFilesToDelete(element);
+		if(!filesToDelete.isEmpty()){
+//			IViewPart view = UiUtils.getWorkbenchPage().findView(ScoreViewType.ID);
+			IViewReference[] views = UiUtils.getWorkbenchPage().getViewReferences();
+			for (IViewReference ref : views) {
+				IViewPart view = ref.getView(false);
+				if (view instanceof FileView) {
+					FileView fileView = (FileView)view;
+					IFileViewType<?> fileViewType = fileView.getType();
+					if (fileViewType instanceof PdfViewType) {
+						PdfViewType pdfViewType = (PdfViewType)fileViewType;
+						for (IFile fileToDelete : filesToDelete) {
+							pdfViewType.prepareDelete(fileToDelete);
+						}
+					}
+				}
+			}
+		}
+		return false;
+	}
+
+	private List<IFile> getFilesToDelete(Object element){
+		final List<IFile> result=new ArrayList<IFile>();
+		if(element instanceof IFile){
+			if(isPdf((IFile)element)){
+				result.add((IFile)element);
+			}
+		}else if(element instanceof IFolder){
+			try {
+				((IFolder)element).accept(new IResourceVisitor() {
+					@Override
+					public boolean visit(IResource resource) {
+						if (resource instanceof IFile) {
+							IFile file = (IFile)resource;
+							if(isPdf(file)){
+								result.add(file);
+							}
+						}
+						return true;
+					}
+				});
+			} catch (CoreException e) {
+				Activator.logError("error traversing folder to delete", e);
+			}
+		}
+		return result;
+	}
+
+	private boolean isPdf(IFile file){
+		return file.getFileExtension().equals(PdfViewType.EXTENSION);
+	}
+
+	@Override
+	public String getName() {
+		return "Close Score View";
+	}
+
+	@Override
+	public RefactoringStatus checkConditions(IProgressMonitor pm, CheckConditionsContext context) throws OperationCanceledException {
+		return new RefactoringStatus();
+	}
+
+	@Override
+	public Change createChange(IProgressMonitor pm) throws CoreException, OperationCanceledException {
+		return null;
+	}
+}

--- a/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewType.java
+++ b/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewType.java
@@ -1,5 +1,8 @@
 package org.eclipse.ui.views.pdf;
 
+import java.util.Map;
+import java.util.WeakHashMap;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.jface.action.IContributionItem;
 import org.eclipse.ui.part.PageBook;
@@ -10,9 +13,13 @@ public class PdfViewType implements IFileViewType<PdfViewPage> {
 
 	public static final String EXTENSION = "pdf"; //$NON-NLS-1$
 
+	Map<IFile, PdfViewPage> pages=new WeakHashMap<IFile,PdfViewPage>();
+	
 	@Override
 	public PdfViewPage createPage(PageBook pageBook, IFile file) throws Exception {
-		return new PdfViewPage(pageBook, file);
+		PdfViewPage result = new PdfViewPage(pageBook, file);
+		pages.put(file, result);
+		return result;
 	}
 
 	private final PdfViewToolbarManager toolbar = new PdfViewToolbarManager();
@@ -30,6 +37,14 @@ public class PdfViewType implements IFileViewType<PdfViewPage> {
 
 	public PdfViewPage getPage() {
 		return page;
+	}
+
+	public void prepareDelete(IFile file){
+		PdfViewPage view = pages.get(file);
+		if(view!=null){
+			view.closeFile();
+			pages.remove(file);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Here is another attempt to fix https://github.com/thSoft/elysium/issues/1

A DeleteParticipant in Elysium is not enough. Using the code from LilyPondHyperlinkHelper in order to obtain the score view you get acces to the currently visible PdfViewPage, but there is one for every pdf file that was opened once. If "Link with Editor and Selection" is disabled ore if a folder is deleted, there is no chance to access those hidden PdfViewPages in order to close their files as well.

So because the commons-code had to be modified anyway in order to close all files, I put the DeleteParticipant here.
