### PR TITLE
do not try to open editor if file does not exist

### DIFF
--- a/org.eclipse.util/src/org/eclipse/util/TextEditorUtils.java
+++ b/org.eclipse.util/src/org/eclipse/util/TextEditorUtils.java
@@ -1,7 +1,14 @@
 package org.eclipse.util;
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.jface.dialogs.PopupDialog;
 import org.eclipse.jface.text.IDocument;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IFileEditorInput;
 import org.eclipse.ui.IWorkbenchPage;
@@ -23,6 +30,10 @@ public class TextEditorUtils {
 	public static void revealPosition(IFileEditorInput editorInput, int lineNumber, int columnNumber, int tabWidth) {
 		try {
 			IFile file = editorInput.getFile();
+			if (!file.exists()) {
+				openFileNotFoundPopup(file);
+				return;
+			}
 			IWorkbenchPage page = UiUtils.getWorkbenchPage();
 			IEditorPart editor = IDE.openEditor(page, file);
 			if (editor instanceof TextEditor) {
@@ -42,4 +53,22 @@ public class TextEditorUtils {
 		}
 	}
 
+	private static void openFileNotFoundPopup(final IFile file) {
+		PopupDialog popup = new PopupDialog(Display.getDefault().getActiveShell(), PopupDialog.INFOPOPUPRESIZE_SHELLSTYLE, true, false, false, false, false, "Problem occurred", null) {
+
+			@Override
+			protected Control createDialogArea(Composite parent) {
+				Text text = new Text(parent, SWT.MULTI | SWT.READ_ONLY | SWT.WRAP | SWT.NO_FOCUS);
+				text.setText("linked file " + file.getName() + " not found");
+				return text;
+			}
+
+			@Override
+			protected Point getInitialLocation(Point initialSize) {
+				Point cursorLocation = Display.getDefault().getCursorLocation();
+				return new Point(cursorLocation.x + 20, cursorLocation.y);
+			}
+		};
+		popup.open();
+	}
 }


### PR DESCRIPTION
If you open the score view in Elysium, delete the underlying .ly file and click on a pdf hyperlink an editor with no content is opened. So far so good. But you also get an NPE by the Xtext highlighter which is not so nice.

If the file does not exist (and we know that), opening it should not be attempted at all. The error dialog is a matter of taste. Having no feedback at all might be unexpected!?
