### PR TITLE
reduce memory leaks

### DIFF
--- a/org.eclipse.ui.views.file/src/org/eclipse/ui/views/file/FileView.java
+++ b/org.eclipse.ui.views.file/src/org/eclipse/ui/views/file/FileView.java
@@ -280,9 +280,7 @@ public class FileView extends ViewPart {
 
 	public void reload(IFile file) {
 		Composite oldPage = pages.get(file);
-		if (oldPage == null) {
-			load(file);
-		} else {
+		if (oldPage != null) {
 			if (file.exists()) {
 				try {
 					getType().reload(oldPage);
@@ -293,9 +291,9 @@ public class FileView extends ViewPart {
 			} else {
 				pages.put(file, null);
 			}
-		}
-		if (file.equals(getFile())) {
-			refresh();
+			if (file.equals(getFile())) {
+				refresh();
+			}
 		}
 	}
 

--- a/org.eclipse.ui.views.file/src/org/eclipse/ui/views/file/FileView.java
+++ b/org.eclipse.ui.views.file/src/org/eclipse/ui/views/file/FileView.java
@@ -1,10 +1,12 @@
 package org.eclipse.ui.views.file;
 
 import static java.text.MessageFormat.format;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
@@ -185,6 +187,11 @@ public class FileView extends ViewPart {
 			}
 		}
 		super.dispose();
+		pageBook=null;
+		pages.clear();
+		ISelectionService selectionService = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getSelectionService();
+		selectionService.removePostSelectionListener(selectionListener);
+
 	}
 
 	public List<String> getExtensions() {
@@ -200,7 +207,7 @@ public class FileView extends ViewPart {
 	}
 
 	public void show(IFile file) {
-		if (!pageBook.isDisposed()) {
+		if (pageBook!=null && !pageBook.isDisposed()) {
 			pageBook.setVisible(true);
 			setFile(file);
 			setTitleToolTip(file.getFullPath().toString());

--- a/org.eclipse.ui.views.midi/src/org/eclipse/ui/views/midi/MidiViewPage.java
+++ b/org.eclipse.ui.views.midi/src/org/eclipse/ui/views/midi/MidiViewPage.java
@@ -97,7 +97,11 @@ public class MidiViewPage extends ScrolledComposite {
 	}
 
 	public void closeFile() {
+		pause();
+		synthesizer.close();
 		sequencer.close();
+		content.dispose();
+		this.dispose();
 	}
 
 	// Playback
@@ -122,8 +126,10 @@ public class MidiViewPage extends ScrolledComposite {
 	}
 
 	public void pause() {
-		sequencer.stop();
-		getPlaybackAction().setPlaying(false);
+		if(sequencer.isOpen()){
+			sequencer.stop();
+			getPlaybackAction().setPlaying(false);
+		}
 	}
 
 	public boolean isPlaying() {

--- a/org.eclipse.ui.views.midi/src/org/eclipse/ui/views/midi/MidiViewType.java
+++ b/org.eclipse.ui.views.midi/src/org/eclipse/ui/views/midi/MidiViewType.java
@@ -49,6 +49,18 @@ public class MidiViewType implements IFileViewType<MidiViewPage> {
 	@Override
 	public void pageClosed(MidiViewPage page) {
 		page.closeFile();
+		if(this.page!=null && this.page.getFile().equals(page.getFile())){
+			if(!this.page.isDisposed()){
+				this.page.closeFile();
+			}
+			setPage(null);
+		}
+		if(toolbar.getPage()!=null && toolbar.getPage().getFile().equals(page.getFile())){
+			if(!toolbar.getPage().isDisposed()){
+				toolbar.getPage().closeFile();
+			}
+			toolbar.setPage(null);
+		}
 	}
 
 	@Override

--- a/org.eclipse.ui.views.midi/src/org/eclipse/ui/views/midi/NumericValueEditor.java
+++ b/org.eclipse.ui.views.midi/src/org/eclipse/ui/views/midi/NumericValueEditor.java
@@ -23,6 +23,9 @@ public class NumericValueEditor extends Composite {
 	public void setValue(int value, boolean callback) {
 		value = Math.max(0, Math.min(getMaximumValue(), value));
 		this.value = value;
+		if(slider.isDisposed()){
+			return;
+		}
 		slider.setSelection(value);
 		displayer.setText(MessageFormat.format("{0}/{1}", hooks.display(value), hooks.display(getMaximumValue())));
 		if (callback) {

--- a/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewType.java
+++ b/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewType.java
@@ -1,6 +1,7 @@
 package org.eclipse.ui.views.pdf;
 
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.WeakHashMap;
 
 import org.eclipse.core.resources.IFile;
@@ -68,6 +69,24 @@ public class PdfViewType implements IFileViewType<PdfViewPage> {
 	@Override
 	public void pageClosed(PdfViewPage page) {
 		page.closeFile();
+		if(this.page!=null && this.page.getFile().equals(page.getFile())){
+			if(!this.page.isDisposed()){
+				this.page.closeFile();
+			}
+			setPage(null);
+		}
+		if(toolbar.getPage()!=null && toolbar.getPage().getFile().equals(page.getFile())){
+			if(!toolbar.getPage().isDisposed()){
+				toolbar.getPage().closeFile();
+			}
+			toolbar.setPage(null);
+		}
+		for (Entry<IFile, PdfViewPage> entry : pages.entrySet()) {
+			if(page.equals(entry.getValue())){
+				pages.remove(entry.getKey());
+				break;
+			}
+		}
 	}
 
 	@Override


### PR DESCRIPTION
During full builds I noticed memory usage going up, in particular if score and midi views are open (see number of running threads in debug modus and very basic memory sampling using jvisualvm). However, closing the views did not release the memory. The main reason was that references to the ViewPages (and their members) were not released.

96189d64322cb88096f17c5338e69b6e27b4cc2b cleans up as much as I was able to achieve so far.

7725474fcc787d582c5dcfc4faf2fe51a6d3a400 prevents all files to be added to the views during a full build - reload should really only reload an already known file.

These changes are somewhat related to #4.
