### PR TITLE
fix issues related to closing documents

### DIFF
--- a/org.eclipse.ui.views.file/src/org/eclipse/ui/views/file/FileView.java
+++ b/org.eclipse.ui.views.file/src/org/eclipse/ui/views/file/FileView.java
@@ -426,6 +426,7 @@ public class FileView extends ViewPart {
 				getType().pageClosed(composite);
 				if(file.equals(getFile())){
 					fileNameDisplay.setText("");//$NON-NLS-1$
+					setFile(null);
 				}
 			}
 		}

--- a/org.eclipse.ui.views.file/src/org/eclipse/ui/views/file/FileView.java
+++ b/org.eclipse.ui.views.file/src/org/eclipse/ui/views/file/FileView.java
@@ -299,6 +299,7 @@ public class FileView extends ViewPart {
 		for (IContributionItem contributionItem : toolbarContributions) {
 			contributionItem.setVisible(false);
 		}
+		toolbar.update(true);
 	}
 
 	private void refreshToolbarContributions() {
@@ -432,6 +433,7 @@ public class FileView extends ViewPart {
 				if(file.equals(getFile())){
 					fileNameDisplay.setText("");//$NON-NLS-1$
 					setFile(null);
+					showErrorPage();
 				}
 			}
 		}

--- a/org.eclipse.ui.views.file/src/org/eclipse/ui/views/file/FileView.java
+++ b/org.eclipse.ui.views.file/src/org/eclipse/ui/views/file/FileView.java
@@ -22,6 +22,7 @@ import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.IContributionItem;
 import org.eclipse.jface.action.IToolBarManager;
 import org.eclipse.jface.action.Separator;
+import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.swt.SWT;
@@ -129,16 +130,17 @@ public class FileView extends ViewPart {
 		registerToolbarActionShortcuts();
 		
 		// Restore settings
-		if (memento != null) {
+		IDialogSettings dialogSettings = Activator.getInstance().getDialogSettings();
+		if (dialogSettings != null) {
 			// Path
-			String pathString = memento.getString(PATH);
+			String pathString = dialogSettings.get(PATH);
 			if (pathString != null) {
 				IPath path = Path.fromPortableString(pathString);
 				IFile file = ResourcesPlugin.getWorkspace().getRoot().getFileForLocation(path);
 				setFile(file);
 			}
 			// Linked
-			Boolean linked = memento.getBoolean(LINKED);
+			Boolean linked = dialogSettings.getBoolean(LINKED);
 			if (linked != null) {
 				this.linked = linked;
 			}
@@ -199,14 +201,17 @@ public class FileView extends ViewPart {
 		pageBook.setFocus();
 	}
 
-	@Override
-	public void saveState(IMemento memento) {
-		memento.putString(PATH, (file == null || file.getLocation() == null) ? null : file.getLocation().toPortableString());
-		memento.putBoolean(LINKED, linked);
+	private void saveSettings() {
+		IDialogSettings dialogSettings = Activator.getInstance().getDialogSettings();
+		if(dialogSettings!=null){
+			dialogSettings.put(PATH, (file == null || file.getLocation() == null) ? null : file.getLocation().toPortableString());
+			dialogSettings.put(LINKED, linked);
+		}
 	}
 
 	@Override
 	public void dispose() {
+		saveSettings();
 		for (Composite page : pages.values()) {
 			if (page != null) {
 				getType().pageClosed(page);

--- a/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewPage.java
+++ b/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewPage.java
@@ -72,7 +72,6 @@ public class PdfViewPage extends ScrolledComposite {
 
 		@Override
 		public IStatus run(final IProgressMonitor monitor) {
-			ensureLoadAnnotationsJobDoesNotAccessPdfDecoder();
 			if(monitor.isCanceled()){
 				return Status.CANCEL_STATUS;
 			}
@@ -108,11 +107,6 @@ public class PdfViewPage extends ScrolledComposite {
 			}
 			return monitor.isCanceled()?Status.CANCEL_STATUS:Status.OK_STATUS;
 		}
-
-		private void ensureLoadAnnotationsJobDoesNotAccessPdfDecoder(){
-			loadAnnotationsJob.cancel();
-			waitForJob(loadAnnotationsJob);
-		}
 	};
 
 
@@ -129,6 +123,9 @@ public class PdfViewPage extends ScrolledComposite {
 	public void redraw() {
 		if (isFileOpen()) {
 			renderJob.cancel();
+			loadAnnotationsJob.cancel();
+			createHyperlinksJob.cancel();
+			waitForJob(loadAnnotationsJob);
 			renderJob.schedule();
 			waitForJob(renderJob);
 			createHyperlinks();

--- a/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewPage.java
+++ b/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewPage.java
@@ -106,6 +106,16 @@ public class PdfViewPage extends ScrolledComposite {
 
 	};
 
+
+	@Override
+	public boolean setFocus() {
+		//prevent setting focus to child element (pdf annotation) causing accidental scrolling
+		//copied from Control#setFocus
+		checkWidget ();
+		if ((getStyle() & SWT.NO_FOCUS) != 0) return false;
+		return forceFocus ();
+	};
+
 	@Override
 	public void redraw() {
 		if (isFileOpen()) {

--- a/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewToolbarManager.java
+++ b/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewToolbarManager.java
@@ -87,7 +87,8 @@ public class PdfViewToolbarManager {
 
 		@Override
 		public boolean isEnabled() {
-			return getPage()!=null && getPage().isPageValid(getNewPage());
+			int newPage=getNewPage();
+			return getPage()!=null && getPage().isPageValid(newPage) && getPage().getPage()!=newPage;
 		}
 
 	}

--- a/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewToolbarManager.java
+++ b/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewToolbarManager.java
@@ -87,7 +87,7 @@ public class PdfViewToolbarManager {
 
 		@Override
 		public boolean isEnabled() {
-			return getPage().isPageValid(getNewPage());
+			return getPage()!=null && getPage().isPageValid(getNewPage());
 		}
 
 	}
@@ -178,6 +178,9 @@ public class PdfViewToolbarManager {
 
 				@Override
 				public void keyPressed(KeyEvent event) {
+					if(getPage()==null){
+						return;
+					}
 					if ((event.keyCode == SWT.CR) && (text.getText().length() > 0)) {
 						getPage().setPage(Integer.parseInt(text.getText()));
 					}
@@ -261,7 +264,7 @@ public class PdfViewToolbarManager {
 
 		@Override
 		public boolean isEnabled() {
-			return getPage().isZoomValid(getNewZoom());
+			return getPage()!=null && getPage().isZoomValid(getNewZoom());
 		}
 
 	}
@@ -377,6 +380,11 @@ public class PdfViewToolbarManager {
 					}
 				}
 			}
+		}
+
+		@Override
+		public boolean isEnabled() {
+			return getPage()!=null &&super.isEnabled();
 		}
 
 	}

--- a/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewToolbarManager.java
+++ b/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewToolbarManager.java
@@ -228,6 +228,9 @@ public class PdfViewToolbarManager {
 			GridData layoutData = new GridData();
 			layoutData.verticalAlignment = SWT.CENTER;
 			layoutData.grabExcessVerticalSpace = true;
+			//TODO remove hint once resizing the label works
+			layoutData.widthHint=22;
+			layoutData.horizontalAlignment=SWT.CENTER;
 			label.setLayoutData(layoutData);
 			update();
 			return container;

--- a/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewToolbarManager.java
+++ b/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewToolbarManager.java
@@ -182,7 +182,7 @@ public class PdfViewToolbarManager {
 					if(getPage()==null){
 						return;
 					}
-					if ((event.keyCode == SWT.CR) && (text.getText().length() > 0)) {
+					if ((event.keyCode == SWT.CR || event.keyCode==SWT.KEYPAD_CR) && (text.getText().length() > 0)) {
 						getPage().setPage(Integer.parseInt(text.getText()));
 					}
 				}


### PR DESCRIPTION
The commits fix NPEs and related issues that arise when a document is closed but the actions stayed enabled.
Further I changed persisting the FileView settings from IMemento to DialogSettings. The advantage is that changes are persisted also when the view itself is closed, not only when Eclipse is shut down. This way the beahviour is much more intuitive if you close the view and open it again.
