### PR TITLE
#14 enable editing support in midi view

### DIFF
--- a/org.eclipse.ui.views.midi/src/org/eclipse/ui/views/midi/MidiViewPage.java
+++ b/org.eclipse.ui.views.midi/src/org/eclipse/ui/views/midi/MidiViewPage.java
@@ -240,7 +240,7 @@ public class MidiViewPage extends ScrolledComposite {
 	private TableViewer tracks;
 
 	private void addTracks(Composite parent) {
-		tracks = new TableViewer(parent, SWT.BORDER | SWT.NO_SCROLL);
+		tracks = new TableViewer(parent, SWT.BORDER | SWT.NO_SCROLL|SWT.FULL_SELECTION);
 		for (TrackColumn trackColumn : TrackColumn.values()) {
 			TableViewerColumn tableViewerColumn = new TableViewerColumn(tracks, SWT.NONE);
 			tableViewerColumn.setEditingSupport(new TrackEditingSupport(tracks, trackColumn));


### PR DESCRIPTION
The javadoc for TableViewerColumn#setEditingSupport states that the SWT.FULL_SELECTION bit must be passed to the viewer. Without it, muting tracks is not possible on my system; having added it, the check box cell editors are working.

The current semantics of combining activation of solo and mute may not be as intuitive as expected. Selecting one track (or more) as solo, I'd expect all other tracks to be marked as mute automatically.
