### PR TITLE
fix pdf view scrolling bugs

### DIFF
--- a/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewPage.java
+++ b/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewPage.java
@@ -64,6 +64,7 @@ public class PdfViewPage extends ScrolledComposite {
 		}
 		setShowFocusedControl(true);
 		setContent(pdfDisplay);
+		PdfViewScrollHandler.fixNegativeOriginMouseScrollBug(this);
 	}
 
 	// Rendering

--- a/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewScrollHandler.java
+++ b/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewScrollHandler.java
@@ -59,31 +59,23 @@ public class PdfViewScrollHandler implements IHandler{
 		PdfViewPage page = getPage();
 		if(page!=null && (event.getTrigger()) instanceof Event){
 			int key=((Event)event.getTrigger()).keyCode;
-			int hInc=page.getHorizontalBar().getIncrement();
-			int vInc=page.getVerticalBar().getIncrement();
-			Point currentOrigin=page.getOrigin();
-			int xToSet=currentOrigin.x;
-			int yToSet=currentOrigin.y;
 			switch(key){
-				case SWT.ARROW_UP:yToSet=getNewValue(yToSet, -vInc);break;
-				case SWT.ARROW_DOWN:yToSet=getNewValue(yToSet, vInc);break;
-				case SWT.ARROW_LEFT:xToSet=getNewValue(xToSet, -hInc);break;
-				case SWT.ARROW_RIGHT:xToSet=getNewValue(xToSet, hInc);break;
+				case SWT.ARROW_UP:scroll(page.getVerticalBar(),true);break;
+				case SWT.ARROW_DOWN:scroll(page.getVerticalBar(),false);break;
+				case SWT.ARROW_LEFT:scroll(page.getHorizontalBar(),true);break;
+				case SWT.ARROW_RIGHT:scroll(page.getHorizontalBar(),false);break;
 				default:return null;
-			}
-			if(xToSet!=currentOrigin.x || yToSet!=currentOrigin.y){
-				page.setOrigin(xToSet, yToSet);
 			}
 		}
 		return null;
 	}
 
-	private int getNewValue(int current, int offset){
-		if(current>=0){
-			return current+offset;
-		}else{
-			//no scrolling possible, page already smaller than frame
-			return current;
+	private void scroll(ScrollBar bar, boolean up){
+		int inc = up?-bar.getIncrement():bar.getIncrement();
+		bar.setSelection(bar.getSelection()+inc);
+		Listener[] listeners = bar.getListeners(SWT.Selection);
+		for (Listener listener : listeners) {
+			listener.handleEvent(new Event());
 		}
 	}
 

--- a/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewScrollHandler.java
+++ b/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewScrollHandler.java
@@ -34,18 +34,27 @@ public class PdfViewScrollHandler implements IHandler{
 			Point currentOrigin=page.getOrigin();
 			int xToSet=currentOrigin.x;
 			int yToSet=currentOrigin.y;
-			if(xToSet>=0 && yToSet>=0){
-				switch(key){
-					case SWT.ARROW_UP:yToSet-=vInc;break;
-					case SWT.ARROW_DOWN:yToSet+=vInc;break;
-					case SWT.ARROW_LEFT:xToSet-=hInc;break;
-					case SWT.ARROW_RIGHT:xToSet+=hInc;break;
-					default:return null;
-				}
+			switch(key){
+				case SWT.ARROW_UP:yToSet=getNewValue(yToSet, -vInc);break;
+				case SWT.ARROW_DOWN:yToSet=getNewValue(yToSet, vInc);break;
+				case SWT.ARROW_LEFT:xToSet=getNewValue(xToSet, -hInc);break;
+				case SWT.ARROW_RIGHT:xToSet=getNewValue(xToSet, hInc);break;
+				default:return null;
+			}
+			if(xToSet!=currentOrigin.x || yToSet!=currentOrigin.y){
 				page.setOrigin(xToSet, yToSet);
 			}
 		}
 		return null;
+	}
+
+	private int getNewValue(int current, int offset){
+		if(current>=0){
+			return current+offset;
+		}else{
+			//no scrolling possible, page already smaller than frame
+			return current;
+		}
 	}
 
 	@Override

--- a/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewToolbarManager.java
+++ b/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewToolbarManager.java
@@ -1,6 +1,7 @@
 package org.eclipse.ui.views.pdf;
 
 import java.text.MessageFormat;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.ActionContributionItem;
@@ -326,9 +327,15 @@ public class PdfViewToolbarManager {
 	public class FitToAction extends Action {
 
 		private final ControlListener resizeListener = new ControlAdapter() {
+			private AtomicBoolean preventZoomingToOftenLock=new AtomicBoolean(false);
 
 			@Override
 			public void controlResized(ControlEvent e) {
+				if(preventZoomingToOftenLock.get()){
+					//workaround for for problem described in pull request 17
+					return;
+				}
+				preventZoomingToOftenLock.set(true);
 				PdfViewPage page = getPage();
 				float widthRatio = Float.MAX_VALUE;
 				if (fitToWidth) {
@@ -343,6 +350,7 @@ public class PdfViewToolbarManager {
 					heightRatio = imageHeight / pageHeight;
 				}
 				page.setZoom(Math.min(widthRatio, heightRatio));
+				preventZoomingToOftenLock.set(false);
 			}
 
 		};


### PR DESCRIPTION
This should fix the key scrolling issue. Previously, keys active only if scrolling in all directions was possible.

When investigating this, I ran into a nasty deadlock problem! When a "fit to" action is active, resizing the score view (continuously using mouse dragging) causes the ControlListener in PdfViewToolbarManager (line 345) to call page.setZoom very often in a short period of time.
But now, obtaining the image is not part of the synchronized Execution in the RenderJob anymore, potentially causing a deadlock.
