### PR TITLE
#18 store settings per file view type

### DIFF
--- a/org.eclipse.ui.views.file/src/org/eclipse/ui/views/file/FileView.java
+++ b/org.eclipse.ui.views.file/src/org/eclipse/ui/views/file/FileView.java
@@ -133,14 +133,14 @@ public class FileView extends ViewPart {
 		IDialogSettings dialogSettings = Activator.getInstance().getDialogSettings();
 		if (dialogSettings != null) {
 			// Path
-			String pathString = dialogSettings.get(PATH);
+			String pathString = dialogSettings.get(getSettingsKey(PATH));
 			if (pathString != null) {
 				IPath path = Path.fromPortableString(pathString);
 				IFile file = ResourcesPlugin.getWorkspace().getRoot().getFileForLocation(path);
 				setFile(file);
 			}
 			// Linked
-			Boolean linked = dialogSettings.getBoolean(LINKED);
+			Boolean linked = dialogSettings.getBoolean(getSettingsKey(LINKED));
 			if (linked != null) {
 				this.linked = linked;
 			}
@@ -204,9 +204,13 @@ public class FileView extends ViewPart {
 	private void saveSettings() {
 		IDialogSettings dialogSettings = Activator.getInstance().getDialogSettings();
 		if(dialogSettings!=null){
-			dialogSettings.put(PATH, (file == null || file.getLocation() == null) ? null : file.getLocation().toPortableString());
-			dialogSettings.put(LINKED, linked);
+			dialogSettings.put(getSettingsKey(PATH), (file == null || file.getLocation() == null) ? null : file.getLocation().toPortableString());
+			dialogSettings.put(getSettingsKey(LINKED), linked);
 		}
+	}
+
+	private String getSettingsKey(String prefix){
+		return prefix+getType().getClass().getSimpleName();
 	}
 
 	@Override


### PR DESCRIPTION
Make the key for storing the settings depend on the view type, so there are distinct keys for score and audio view. (Another option would be using dialogSettings sections.)
