### PR TITLE
#20 fix broken hyperlinks

### DIFF
--- a/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewPage.java
+++ b/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewPage.java
@@ -462,7 +462,7 @@ public class PdfViewPage extends ScrolledComposite {
 			return null;
 		}
 
-		private void addRawObjectToPdfAnnotationList(FormObject formObject, List<PdfAnnotation> list, Map<String, IFile> fileCache){
+		private void addRawObjectToPdfAnnotationList(Integer page, FormObject formObject, List<PdfAnnotation> list, Map<String, IFile> fileCache){
 				int subtype = formObject.getParameterConstant(PdfDictionary.Subtype);
 				if (subtype == PdfDictionary.Link) {
 					PdfObject anchor = formObject.getDictionary(PdfDictionary.A);
@@ -524,7 +524,7 @@ public class PdfViewPage extends ScrolledComposite {
 			while (!monitor.isCanceled() && pdfAnnotations.hasMoreTokens()) {
 				String key = pdfAnnotations.getNextValueAsString(true);
 				FormObject rawObject = formRenderer.getFormObject(key);
-				addRawObjectToPdfAnnotationList(rawObject, annotationsOnPage, fileCache);
+				addRawObjectToPdfAnnotationList(page, rawObject, annotationsOnPage, fileCache);
 			}
 			return annotationsOnPage;
 		}


### PR DESCRIPTION
When extracting the method the parameter page got lost and caused no compile errors. The field page had the correct type - hence the linking on page 1 only - all annotations were created for that initial page.
