### PR TITLE
prevent illegal thread access during refactoring

### DIFF
--- a/org.eclipse.ui.views.file/META-INF/MANIFEST.MF
+++ b/org.eclipse.ui.views.file/META-INF/MANIFEST.MF
@@ -8,7 +8,8 @@ Export-Package: org.eclipse.ui.views.file
 Require-Bundle: org.eclipse.core.resources;bundle-version="3.6.0";visibility:=reexport,
  org.eclipse.ui;bundle-version="3.6.0",
  org.eclipse.core.runtime;bundle-version="3.6.0",
- org.eclipse.util;bundle-version="0.0.0"
+ org.eclipse.util;bundle-version="0.0.0",
+ org.eclipse.ui.ide
 Bundle-Vendor: Open Source Community
 Import-Package: org.eclipse.ui.dialogs
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.ui.views.file/src/org/eclipse/ui/views/file/FileView.java
+++ b/org.eclipse.ui.views.file/src/org/eclipse/ui/views/file/FileView.java
@@ -42,13 +42,16 @@ import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.part.EditorPart;
+import org.eclipse.ui.part.FileEditorInput;
+import org.eclipse.ui.part.IShowInTarget;
 import org.eclipse.ui.part.PageBook;
+import org.eclipse.ui.part.ShowInContext;
 import org.eclipse.ui.part.ViewPart;
 
 /**
  * A view that displays the file determined by its current source.
  */
-public class FileView extends ViewPart {
+public class FileView extends ViewPart implements IShowInTarget{
 
 	public static final String BINDINGS = "bindings"; //$NON-NLS-1$
 
@@ -471,4 +474,29 @@ public class FileView extends ViewPart {
 			return result;
 		};
 	};
+
+	@Override
+	public boolean show(ShowInContext context) {
+		if (context == null)
+			return false;
+		Object potentialFile=null;
+		ISelection sel = context.getSelection();
+		if (sel instanceof IStructuredSelection) {
+			IStructuredSelection ss = (IStructuredSelection) sel;
+			potentialFile = ss.getFirstElement();
+		}else{
+			Object input = context.getInput();
+			if(input instanceof FileEditorInput){
+				potentialFile=((FileEditorInput)input).getFile();
+			}
+		}
+		if (potentialFile instanceof IFile) {
+			IFile actualFileToOpen = type.getFile((IFile) potentialFile);
+			if (actualFileToOpen.exists()) {
+				show(actualFileToOpen);
+				return true;
+			}
+		}
+		return false;
+	}
 }

--- a/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewPage.java
+++ b/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewPage.java
@@ -411,10 +411,12 @@ public class PdfViewPage extends ScrolledComposite {
 	private final Job resetAnnotationsJob=new Job("Resetting point-and-click hyperlinks"){
 		@Override
 		public IStatus run(IProgressMonitor monitor) {
-			renderJob.cancel();
-			loadAnnotationsJob.cancel();
-			waitForJob(loadAnnotationsJob);
-			annotations.clear();
+			if(renderJob.getResult() != null){
+				renderJob.cancel();
+				loadAnnotationsJob.cancel();
+				waitForJob(loadAnnotationsJob);
+				annotations.clear();
+			}
 			return Status.OK_STATUS;
 		}
 	};
@@ -587,16 +589,13 @@ public class PdfViewPage extends ScrolledComposite {
 		}
 
 		private void waitForPageAnnotationsToBeLoaded(IProgressMonitor monitor){
-			if(renderJob.getResult()==null){
-				renderJob.schedule();
-			}
 			while(!annotations.containsKey(page)){
 				monitor.setTaskName("waiting for annotations to be loaded");
 				if(monitor.isCanceled()){
 					return;
 				}
 				pageWithPriorityToLoad=page;
-				if(loadAnnotationsJob.getResult()==Status.CANCEL_STATUS){
+				if(loadAnnotationsJob.getResult()==Status.CANCEL_STATUS || loadAnnotationsJob.getResult()==null){
 					loadAnnotationsJob.schedule();
 				}
 				waitForJob(loadAnnotationsJob);

--- a/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewPage.java
+++ b/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewPage.java
@@ -166,7 +166,9 @@ public class PdfViewPage extends ScrolledComposite {
 			renderJob.obtainImage();
 			renderJob.schedule();
 			waitForJob(renderJob);
-			createHyperlinks();
+			if(renderJob.getResult()!=null){
+				createHyperlinks();
+			}
 		}
 	}
 

--- a/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewPage.java
+++ b/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewPage.java
@@ -166,9 +166,7 @@ public class PdfViewPage extends ScrolledComposite {
 			renderJob.obtainImage();
 			renderJob.schedule();
 			waitForJob(renderJob);
-			if(renderJob.getResult()!=null){
-				createHyperlinks();
-			}
+			createHyperlinks();
 		}
 	}
 
@@ -589,6 +587,9 @@ public class PdfViewPage extends ScrolledComposite {
 		}
 
 		private void waitForPageAnnotationsToBeLoaded(IProgressMonitor monitor){
+			if(renderJob.getResult()==null){
+				renderJob.schedule();
+			}
 			while(!annotations.containsKey(page)){
 				monitor.setTaskName("waiting for annotations to be loaded");
 				if(monitor.isCanceled()){

--- a/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/refactoring/PdfViewPageCloser.java
+++ b/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/refactoring/PdfViewPageCloser.java
@@ -8,6 +8,7 @@ import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceVisitor;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IViewReference;
 import org.eclipse.ui.views.file.FileView;
@@ -31,9 +32,14 @@ public class PdfViewPageCloser {
 					IFileViewType<?> fileViewType = fileView.getType();
 					if (fileViewType instanceof PdfViewType) {
 						PdfViewType pdfViewType = (PdfViewType)fileViewType;
-						for (IFile fileToRelease : filesToRelease) {
-							pdfViewType.release(fileToRelease);
-						}
+						Display.getDefault().syncExec(new Runnable(){
+							@Override
+							public void run() {
+								for (IFile fileToRelease : filesToRelease) {
+									pdfViewType.release(fileToRelease);
+								}
+							}
+						});
 					}
 				}
 			}


### PR DESCRIPTION
If the score view is open and you try to rename the corresponding source file, trying to close the file in the view may throw an SWT exception (illegal thread access).
