### PR TITLE
#4 speed up score focus change

### DIFF
--- a/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewType.java
+++ b/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewType.java
@@ -37,6 +37,9 @@ public class PdfViewType implements IFileViewType<PdfViewPage> {
 	private PdfViewPage page;
 
 	private void setPage(PdfViewPage page) {
+		if(this.page!=null && page!=this.page){
+			this.page.setPageInactive();
+		}
 		this.page = page;
 	}
 


### PR DESCRIPTION
The disposeHyperlink method is moved for accessibility. The setPageInactive method is introduced for getting rid of obsolete Hyperlinks if another score is activated. The FocusListener deletes hyperlinks on losing focus and creating them on gaining focus, however only if there is no highlighted hyperlink - in this case the redraw method invoked by the HyperlinkAnimator will create them.

The positive effect of this change is that switching beween Score and other views is very fast, no matter how many hyperlinks there are. The (only) negative side effect compared to the previous state is that hyperlinks are not "visible" (e.g. via mouse over) when the score view does not have the focus.

My personal feeling is that the advantage far outweighs the drawback. Please try out the difference with the Mozart or Mendelsson example.

It would be possible to activate/deactivate the focus listener actions depending on the number of annotations, however this would pollute the code even more and make the behaviour inconsistent. Upto 150 notes, the hyperlinks are always visible, with 151 and more they suddenly disappear...