### PR TITLE
#27 eliminate focus delay caused by score in background

### DIFF
--- a/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewPage.java
+++ b/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewPage.java
@@ -213,6 +213,8 @@ public class PdfViewPage extends ScrolledComposite {
 			waitForJob(loadAnnotationsJob);
 			createHyperlinksJob.cancel();
 			waitForJob(createHyperlinksJob);
+			disposeOldHyperlinks();
+			annotationHyperlinkMap.clear();
 			pdfDecoder.closePdfFile();
 		}
 		pdfDisplay.dispose();
@@ -239,6 +241,14 @@ public class PdfViewPage extends ScrolledComposite {
 			this.page = page;
 		}
 		redraw();
+	}
+
+	public void setPageInForeground(boolean putInForeGround){
+		if(!putInForeGround){
+			disposeOldHyperlinks();
+		}else{
+			createHyperlinks();
+		}
 	}
 
 	/**
@@ -551,22 +561,6 @@ public class PdfViewPage extends ScrolledComposite {
 			return monitor.isCanceled()?Status.CANCEL_STATUS:Status.OK_STATUS;
 		}
 
-		private void disposeOldHyperlinks(){
-			Display.getDefault().syncExec(new Runnable() {
-
-				@Override
-				public void run() {
-					if(!pdfDisplay.isDisposed()){
-						Control[] oldHyperlinks = pdfDisplay.getChildren();
-						for (Control oldHyperlink : oldHyperlinks) {
-							oldHyperlink.dispose();
-						}
-					}
-				}
-
-			});
-		}
-
 		private void waitForPageAnnotationsToBeLoaded(IProgressMonitor monitor){
 			while(!annotations.containsKey(page)){
 				monitor.setTaskName("waiting for annotations to be loaded");
@@ -610,6 +604,23 @@ public class PdfViewPage extends ScrolledComposite {
 			});
 		}
 	};
+
+	private void disposeOldHyperlinks(){
+		Display.getDefault().syncExec(new Runnable() {
+
+			@Override
+			public void run() {
+				if(!pdfDisplay.isDisposed()){
+					Control[] oldHyperlinks = pdfDisplay.getChildren();
+					for (Control oldHyperlink : oldHyperlinks) {
+						oldHyperlink.dispose();
+					}
+				}
+			}
+
+		});
+	}
+
 
 	/**
 	 * Creates point-and-click hyperlinks from the hyperlink annotations on the

--- a/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewType.java
+++ b/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewType.java
@@ -33,6 +33,14 @@ public class PdfViewType implements IFileViewType<PdfViewPage> {
 	private PdfViewPage page;
 
 	private void setPage(PdfViewPage page) {
+		if(page!=this.page){
+			if(this.page!=null){
+				this.page.setPageInForeground(false);
+			}
+			if(page!=null){
+				page.setPageInForeground(true);
+			}
+		}
 		this.page = page;
 	}
 


### PR DESCRIPTION
This is a modification less invasive than PR #28. Hyperlinks are not destroyed on focus loss, but only when the score goes to the background. They are recreated once the score is activated again. That way the links are available even if the score view is not in focus.

In order to test the impact of the PR compare the delay of focus change before and after applying the PR:
* Open a score mit many links (e.g. Mozart example)
* Open a score with only one note.
* Make sure the latter is visible
* switch between score view and editor

Without the PR the delay should be about the same as when the complex score is visible, with the PR there should be no delay.