### PR TITLE
prevent refactoring participant NPE

### DIFF
--- a/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/refactoring/PdfViewPageCloser.java
+++ b/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/refactoring/PdfViewPageCloser.java
@@ -75,7 +75,7 @@ public class PdfViewPageCloser {
 	}
 
 	private static boolean isPdf(IFile file){
-		return file.getFileExtension().equals(PdfViewType.EXTENSION);
+		return PdfViewType.EXTENSION.equals(file.getFileExtension());
 	}
 
 }


### PR DESCRIPTION
When deleting a file that has no file extension, the view closer throws an NPE which causes it to be removed from the refactoring participants. 