### PR TITLE
link existing rather than first file

### DIFF
--- a/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewPage.java
+++ b/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewPage.java
@@ -491,8 +491,10 @@ public class PdfViewPage extends ScrolledComposite {
 							}else{
 								URL url = new URL("file", null, path); //$NON-NLS-1$
 								IFile[] files = ResourcesPlugin.getWorkspace().getRoot().findFilesForLocationURI(URIUtil.toURI(url));
-								if(files.length>0){
-									targetFile=files[0];
+								for (IFile iFile : files) {
+									if(iFile.exists()) {
+										targetFile=iFile;
+									}
 								}
 								fileCache.put(path, targetFile);
 							}


### PR DESCRIPTION
The current implementiation uses the first file found for the pdf annotation. This PR changes that using an existing one.

Here is the border case scenario where this makes sense. The same file (file system location) may be present more than once in the workspace, e.g. within an imported project and within a linked file system folder (via import file system). Hence the findFilesForLocationURI-call may really provide more than one IFile. Currently, the first file wins (even if it is the file in a project, which is currently closed and hence cannot be opened).