### PR TITLE
prevent possible join deadlock

### DIFF
--- a/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewPage.java
+++ b/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewPage.java
@@ -119,7 +119,6 @@ public class PdfViewPage extends ScrolledComposite {
 			}
 
 			final BufferedImage awtImage=pageAsImage;
-			final Image swtImage = new Image(Display.getDefault(), ImageUtils.convertBufferedImageToImageData(awtImage));
 			Display.getDefault().syncExec(new Runnable() {
 
 				@Override
@@ -127,6 +126,7 @@ public class PdfViewPage extends ScrolledComposite {
 					if(pdfDisplay.isDisposed()){
 						return;
 					}
+					Image swtImage = new Image(getDisplay(), ImageUtils.convertBufferedImageToImageData(awtImage));
 					Image oldImage = pdfDisplay.getBackgroundImage();
 					if (oldImage != null) {
 						oldImage.dispose();


### PR DESCRIPTION
This PR addresses #41. Moving the image creation into the UI-thread prevents the deadlock. After that a separate guard for was not needed for the join. The change also seems sensible, as new Image() itself needs the display as a parameter.

WIth this modification, deadlocks did not occur anymore for the said actions.