### PR TITLE
#40 generalize PdfAnnotation from IFile to URI

### DIFF
--- a/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfAnnotation.java
+++ b/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfAnnotation.java
@@ -1,10 +1,18 @@
 package org.eclipse.ui.views.pdf;
 
+import java.net.URI;
+
 import org.eclipse.core.resources.IFile;
 
 public class PdfAnnotation {
 
+	@Deprecated
+	/**
+	 * this field will be removed in an upcoming version
+	 * */
 	public IFile file;
+
+	public URI fileURI;
 
 	public int lineNumber;
 

--- a/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfAnnotationHyperlink.java
+++ b/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfAnnotationHyperlink.java
@@ -6,7 +6,6 @@ import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.graphics.Cursor;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.ui.part.FileEditorInput;
 import org.eclipse.util.TextEditorUtils;
 
 public class PdfAnnotationHyperlink extends Composite {
@@ -14,14 +13,16 @@ public class PdfAnnotationHyperlink extends Composite {
 	public PdfAnnotationHyperlink(Composite parent, final PdfAnnotation annotation) {
 		super(parent, SWT.TRANSPARENT | SWT.NO_BACKGROUND); // Both are needed for correct cross-platform behavior
 		setCursor(new Cursor(Display.getDefault(), SWT.CURSOR_HAND));
-		final FileEditorInput editorInput = new FileEditorInput(annotation.file);
 		addMouseListener(new MouseAdapter() {
 
 			@Override
 			public void mouseDown(MouseEvent e) {
-				TextEditorUtils.revealPosition(editorInput, annotation.lineNumber, annotation.columnNumber, 1);
+				if(annotation.fileURI!=null) {
+					TextEditorUtils.revealPosition(annotation.fileURI, annotation.lineNumber, annotation.columnNumber, 1);
+				}else if(annotation.file!=null) {
+					TextEditorUtils.revealPosition(annotation.file, annotation.lineNumber, annotation.columnNumber, 1);
+				}
 			}
-
 		});
 	}
 

--- a/org.eclipse.util/src/org/eclipse/util/TextEditorHyperlink.java
+++ b/org.eclipse.util/src/org/eclipse/util/TextEditorHyperlink.java
@@ -36,7 +36,7 @@ public class TextEditorHyperlink implements IHyperlink {
 	}
 
 	public void linkActivated() {
-		TextEditorUtils.revealPosition(editorInput, lineNumber, columnNumber, tabWidth);
+		TextEditorUtils.revealPosition(editorInput.getFile(), lineNumber, columnNumber, tabWidth);
 	}
 
 	public void linkEntered() {

--- a/org.eclipse.util/src/org/eclipse/util/TextEditorUtils.java
+++ b/org.eclipse.util/src/org/eclipse/util/TextEditorUtils.java
@@ -1,7 +1,11 @@
 package org.eclipse.util;
 
+import java.io.File;
+import java.net.URI;
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.URIUtil;
 import org.eclipse.jface.dialogs.PopupDialog;
+import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Point;
@@ -9,9 +13,11 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Text;
+import org.eclipse.ui.IEditorDescriptor;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IFileEditorInput;
 import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.editors.text.EditorsUI;
 import org.eclipse.ui.editors.text.TextEditor;
 import org.eclipse.ui.ide.IDE;
@@ -23,43 +29,83 @@ public class TextEditorUtils {
 	}
 
 	/**
+	 * use revealPosition(IFile file, int lineNumber, int columnNumber, int
+	 * tabWidth)
+	 *
 	 * Opens the file given by an editor input in a text editor and reveals the
 	 * character at the given position. If the given tab width is 0 or less, the
 	 * actual tab width of the text editor is used.
 	 */
+	@Deprecated
 	public static void revealPosition(IFileEditorInput editorInput, int lineNumber, int columnNumber, int tabWidth) {
+		revealPosition(editorInput.getFile(), lineNumber, columnNumber, tabWidth);
+	}
+
+	public static void revealPosition(URI fileURI, int lineNumber, int columnNumber, int tabWidth) {
+		File file = new File(fileURI);
+		if (!file.exists()) {
+			openErrorPopup(fileNotFoundError(file.getName()));
+		} else {
+			//TODO try to obtain IFile from file and delegate when successful?
+			IEditorDescriptor editorDescriptor = PlatformUI.getWorkbench().getEditorRegistry().getDefaultEditor(file.getName());
+			if (editorDescriptor == null) {
+				openErrorPopup(noEditorFoundError(file.getName()));
+			} else {
+				IWorkbenchPage page = UiUtils.getWorkbenchPage();
+				try {
+					IEditorPart editor = IDE.openEditor(page, URIUtil.toURI(fileURI.toURL()), editorDescriptor.getId(), true);
+					revealPosition(editor, lineNumber, columnNumber, tabWidth);
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+			}
+		}
+	}
+
+	public static void revealPosition(IFile file, int lineNumber, int columnNumber, int tabWidth) {
 		try {
-			IFile file = editorInput.getFile();
 			if (!file.exists()) {
-				openFileNotFoundPopup(file);
+				openErrorPopup(fileNotFoundError(file.getName()));
 				return;
 			}
 			IWorkbenchPage page = UiUtils.getWorkbenchPage();
 			IEditorPart editor = IDE.openEditor(page, file);
-			if (editor instanceof TextEditor) {
-				TextEditor textEditor = (TextEditor)editor;
-				IDocument document = textEditor.getDocumentProvider().getDocument(editorInput);
-
-				int realTabWidth = tabWidth;
-				if (realTabWidth <= 0) {
-					realTabWidth = EditorsUI.getPreferenceStore().getInt(AbstractDecoratedTextEditorPreferenceConstants.EDITOR_TAB_WIDTH);
-				}
-
-				int offset = DocumentUtils.getOffsetOfPosition(document, lineNumber, columnNumber, realTabWidth);
-				textEditor.selectAndReveal(offset, 0);
-			}
+			revealPosition(editor, lineNumber, columnNumber, tabWidth);
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
 	}
 
-	private static void openFileNotFoundPopup(final IFile file) {
+	private static void revealPosition(IEditorPart editor, int lineNumber, int columnNumber, int tabWidth) throws BadLocationException {
+		if (editor instanceof TextEditor) {
+			TextEditor textEditor = (TextEditor)editor;
+			IDocument document = textEditor.getDocumentProvider().getDocument(editor.getEditorInput());
+
+			int realTabWidth = tabWidth;
+			if (realTabWidth <= 0) {
+				realTabWidth = EditorsUI.getPreferenceStore().getInt(AbstractDecoratedTextEditorPreferenceConstants.EDITOR_TAB_WIDTH);
+			}
+
+			int offset = DocumentUtils.getOffsetOfPosition(document, lineNumber, columnNumber, realTabWidth);
+			textEditor.selectAndReveal(offset, 0);
+		}
+	}
+
+	private static String fileNotFoundError(String fileName) {
+		return "linked file " + fileName + " not found";
+	}
+
+	private static String noEditorFoundError(String fileName) {
+		return "no editor found for " + fileName;
+	}
+
+	private static void openErrorPopup(final String errorMessage) {
 		PopupDialog popup = new PopupDialog(Display.getDefault().getActiveShell(), PopupDialog.INFOPOPUPRESIZE_SHELLSTYLE, true, false, false, false, false, "Problem occurred", null) {
 
 			@Override
 			protected Control createDialogArea(Composite parent) {
 				Text text = new Text(parent, SWT.MULTI | SWT.READ_ONLY | SWT.WRAP | SWT.NO_FOCUS);
-				text.setText("linked file " + file.getName() + " not found");
+				text.setText(errorMessage);
 				return text;
 			}
 


### PR DESCRIPTION
With this PR, hyperlinks can be opened from a pdf, even if there is no immediate workspace file available. The primary information in the annotation is the file URI. Based on this the default editor is opened.
IFile is kept for the present in order to ensure compatibility with Elysium (source to score navigation). Once commons is released the new version should be made mandatory for Elysium and source to score navigation must be adapted to match the URI rather than the IFile. After that the deprecated field can be removed from PdfAnnotation.

With respect to Elysium the following issue arises. Previously, hyperlinks to files not in the workspace were not opened at all (because no IFile was found), now they can be opened, but because commons does not know anything about the "LilyPondLanguageSpecificURIEditorOpener", they will not be opened as readOnly...