### PR TITLE
remove unnecessary uri transformation

### DIFF
--- a/org.eclipse.util/src/org/eclipse/util/TextEditorUtils.java
+++ b/org.eclipse.util/src/org/eclipse/util/TextEditorUtils.java
@@ -3,7 +3,6 @@ package org.eclipse.util;
 import java.io.File;
 import java.net.URI;
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.runtime.URIUtil;
 import org.eclipse.jface.dialogs.PopupDialog;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
@@ -53,7 +52,7 @@ public class TextEditorUtils {
 			} else {
 				IWorkbenchPage page = UiUtils.getWorkbenchPage();
 				try {
-					IEditorPart editor = IDE.openEditor(page, URIUtil.toURI(fileURI.toURL()), editorDescriptor.getId(), true);
+					IEditorPart editor = IDE.openEditor(page, fileURI, editorDescriptor.getId(), true);
 					revealPosition(editor, lineNumber, columnNumber, tabWidth);
 				} catch (Exception e) {
 					e.printStackTrace();


### PR DESCRIPTION
#40 introduced a problem with score to source hyperlinks pointing to files whose path contains white spaces. Removing the unnecessary transformation eliminates the problem.

A further current issue is the following. For each opened link (outside workspace), a new editor is opened (rather than checking whether an already opened editor shows the same file).