### PR TITLE
normalize URI

### DIFF
--- a/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewPage.java
+++ b/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewPage.java
@@ -486,8 +486,9 @@ public class PdfViewPage extends ScrolledComposite {
 							IFile targetIFile=null;
 							File targetFile = new File(path).getAbsoluteFile();
 							if(targetFile.exists()) {
-								URI targetURI=targetFile.toURI();
+								URI targetURI=targetFile.toURI().normalize();
 								//TODO all targetIFile will be removed later
+								//reuse file cache for path->targetFile 
 								if(fileCache.containsKey(path)){
 									targetIFile=fileCache.get(path);
 								}else{

--- a/org.eclipse.util/src/org/eclipse/util/TextEditorUtils.java
+++ b/org.eclipse.util/src/org/eclipse/util/TextEditorUtils.java
@@ -52,7 +52,7 @@ public class TextEditorUtils {
 			} else {
 				IWorkbenchPage page = UiUtils.getWorkbenchPage();
 				try {
-					IEditorPart editor = IDE.openEditor(page, fileURI, editorDescriptor.getId(), true);
+					IEditorPart editor = IDE.openEditor(page, fileURI.normalize(), editorDescriptor.getId(), true);
 					revealPosition(editor, lineNumber, columnNumber, tabWidth);
 				} catch (Exception e) {
 					e.printStackTrace();


### PR DESCRIPTION
The URIs should be normalized, so that the same editor is opened no matter where the link comes from.
Normalization is needed in both places. TextEditorUtils could be used from elsewhere, the URI in PdfViewPage will later be used for source to score navigation.

Together with #46 this PR resolves #45.