### PR TITLE
#12 fix page count vertical align (Windows)

### DIFF
--- a/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewToolbarManager.java
+++ b/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewToolbarManager.java
@@ -18,6 +18,8 @@ import org.eclipse.swt.events.MouseAdapter;
 import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.events.VerifyEvent;
 import org.eclipse.swt.events.VerifyListener;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Label;
@@ -218,9 +220,19 @@ public class PdfViewToolbarManager {
 
 		@Override
 		protected Control createControl(Composite parent) {
-			label = new Label(parent, SWT.CENTER);
+			Composite container = new Composite(parent, SWT.NONE);
+			GridLayout layout = new GridLayout();
+			layout.marginHeight = 0;
+			layout.marginWidth = 1;
+			container.setLayout(layout);
+			label = new Label(container, SWT.CENTER);
+			GridData layoutData = new GridData();
+			layoutData.verticalAlignment = SWT.CENTER;
+			layoutData.grabExcessVerticalSpace = true;
+			layoutData.horizontalAlignment=SWT.CENTER;
+			label.setLayoutData(layoutData);
 			update();
-			return label;
+			return container;
 		}
 
 		@Override
@@ -228,10 +240,9 @@ public class PdfViewToolbarManager {
 			if ((label != null) && !label.isDisposed()) {
 				label.setText(MessageFormat.format("/{0}", getPage().getPageCount()));
 				label.setToolTipText("Page count");
-				label.getParent().update();
 			}
 		}
-		
+
 		@Override
 		public boolean isDynamic() {
 			return true;


### PR DESCRIPTION
On windows the vertical alignment is broken without the previously existing container. I added that code again, removed the width hint and added the overriding isDynamic method. The explicit update call to the label's parent was not necessary. Please double check that.