### PR TITLE
#50 revert changes from #32 for windows

### DIFF
--- a/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfAnnotationHyperlink.java
+++ b/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfAnnotationHyperlink.java
@@ -10,8 +10,19 @@ import org.eclipse.util.TextEditorUtils;
 
 public class PdfAnnotationHyperlink extends Composite {
 
+	private static int STYLE= getHyperlinkStyle();
+
+	private static int getHyperlinkStyle() {
+		String system = System.getProperty("os.name", "unknown").toLowerCase();
+		if(system.contains("wins")) {
+			return SWT.NONE; //prevent potential scrolling problems caused by #32
+		}else {
+			return SWT.TRANSPARENT | SWT.NO_BACKGROUND;
+		}
+	}
+
 	public PdfAnnotationHyperlink(Composite parent, final PdfAnnotation annotation) {
-		super(parent, SWT.TRANSPARENT | SWT.NO_BACKGROUND); // Both are needed for correct cross-platform behavior
+		super(parent, STYLE);
 		setCursor(new Cursor(Display.getDefault(), SWT.CURSOR_HAND));
 		addMouseListener(new MouseAdapter() {
 


### PR DESCRIPTION
The fix for overlapping hyperlinks can cause severe scrolling issues in
Windows environments. With SWT.NONE the origianl issue may not even be
present.

Make the style environment specific. This is not nice, but currently much better than the issues caused by transparency under Windows 10.