### PR TITLE
remove deprecated field

### DIFF
--- a/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfAnnotation.java
+++ b/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfAnnotation.java
@@ -2,15 +2,7 @@ package org.eclipse.ui.views.pdf;
 
 import java.net.URI;
 
-import org.eclipse.core.resources.IFile;
-
 public class PdfAnnotation {
-
-	@Deprecated
-	/**
-	 * this field will be removed in an upcoming version
-	 * */
-	public IFile file;
 
 	public URI fileURI;
 

--- a/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfAnnotationHyperlink.java
+++ b/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfAnnotationHyperlink.java
@@ -20,9 +20,6 @@ public class PdfAnnotationHyperlink extends Composite {
 					if (annotation.fileURI != null) {
 						TextEditorUtils.revealPosition(annotation.fileURI, annotation.lineNumber,
 								annotation.columnNumber, 1);
-					} else if (annotation.file != null) {
-						TextEditorUtils.revealPosition(annotation.file, annotation.lineNumber, annotation.columnNumber,
-								1);
 					}
 				}
 			}

--- a/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewPage.java
+++ b/org.eclipse.ui.views.pdf/src/org/eclipse/ui/views/pdf/PdfViewPage.java
@@ -523,7 +523,6 @@ public class PdfViewPage extends ScrolledComposite {
 								PdfAnnotation annotation = new PdfAnnotation();
 								annotation.page = page;
 								annotation.fileURI = targetURI;
-								annotation.file = targetIFile;
 								annotation.lineNumber = Integer.parseInt(sections[1]) - 1;
 								annotation.columnNumber = Integer.parseInt(sections[2]); // This value is independent of tab width
 								float[] rectangle = formObject.getFloatArray(PdfDictionary.Rect);


### PR DESCRIPTION
Remove file from PdfAnnotation. It had been marked deprecated and has been replaced by fileURI. fileURI is already used in Elysium' LilyPondHyperlinkHelper.